### PR TITLE
Update version to 0.57.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
     - opentelemetry-exporter-otlp >=1.34.1,<2
   run_constrained:
-    - mcp >=1.3.0,<2.0.0
+    - mcp >=1.26.0,<2
 
 # Tests not compatible with fastmcp version >3.0.0 (only exist in the main)
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-mcp" %}
-{% set version = "0.49.6" %}
+{% set version = "0.57.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: bcceacdd77af5ff6206c3cadf3afadd20e7bc865e1b94db2f6178a434984d567
+  sha256: e69b078c932e4d7d10a588800000a0d2f0dc49213e90acb77ca2652c82188aee
 
 build:
   number: 0
@@ -18,18 +18,18 @@ requirements:
   host:
     - pip
     - python
-    - poetry-core
+    - hatchling
   run:
     - python
     - opentelemetry-api >=1.38.0,<2.0.0
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
-    - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5
+    - opentelemetry-semantic-conventions-ai <0.6.0,>=0.5
     - opentelemetry-exporter-otlp >=1.34.1,<2
   run_constrained:
     - mcp >=1.3.0,<2.0.0
 
-# Tests not compatible with pytest-asyncio version 1.0.0 (latest in the main), need version >=1.2.0.
+# Tests not compatible with fastmcp version >3.0.0 (only exist in the main)
 test:
   imports:
     - opentelemetry.instrumentation.mcp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - opentelemetry-api >=1.38.0,<2.0.0
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
-    - opentelemetry-semantic-conventions-ai <0.6.0,>=0.5
+    - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
     - opentelemetry-exporter-otlp >=1.34.1,<2
   run_constrained:
     - mcp >=1.3.0,<2.0.0


### PR DESCRIPTION
opentelemetry-instrumentation-mcp 0.57.0

**Destination channel:**  defaults

### Links

- [PKG-13436](https://anaconda.atlassian.net/browse/PKG-13436) 
- [Upstream repository](https://github.com/traceloop/openllmetry/tree/v0.57.0/packages/opentelemetry-instrumentation-mcp)

### Explanation of changes:
- New version number


[PKG-13436]: https://anaconda.atlassian.net/browse/PKG-13436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ